### PR TITLE
Feature/update precommit config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,23 @@ venv.bak/
 
 # Spreadsheets
 *.csv
+
+# Images
+vision_images/
+vision_videos/
+*.raw
+*.jpg
+*.jpeg
+*.png
+*.bag
+*.tiff
+*.bmp
+
+# Videos
+*.avi
+*.mov
+*.mp4
+*.m4a
+*.wmv
+*.mkv
+*.flv

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,32 @@
+## Mypy Configuration File
+
+# Global Options:
+[mypy]
+python_version = 3.8
+# plugins = numpy.typing.mypy_plugin # disabled due to inconsistent problems with different systems
+
+warn_unused_configs = True
+namespace_packages = True
+ignore_missing_imports = True
+disallow_any_generics = True
+disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_redundant_casts = True
+warn_unreachable = True
+local_partial_types = True
+strict_equality = True
+show_error_context = True
+show_column_numbers = True
+show_error_codes = True
+pretty = True
+
+
+
+
+
+
+# Module-Level Options:
+# (None)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,25 +27,7 @@ repos:
     rev: 'v0.931'
     hooks:
     -   id: mypy
-        args:
-          [
-            --namespace-packages,
-            --ignore-missing-imports,
-            --disallow-any-generics,
-            --disallow-untyped-calls,
-            --disallow-untyped-defs,
-            --disallow-incomplete-defs,
-            --disallow-untyped-decorators,
-            --no-implicit-optional,
-            --warn-redundant-casts,
-            --warn-unreachable,
-            --local-partial-types,
-            --strict-equality,
-            --show-error-context,
-            --show-column-numbers,
-            --show-error-codes,
-            --pretty
-          ]
+        args: ["--config-file=.mypy.ini"]
 
 -   repo: https://github.com/PyCQA/pylint
     rev: 'v2.12.2'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,6 @@ repos:
             --namespace-packages,
             --ignore-missing-imports,
             --disallow-any-generics,
-            --disallow-any-explicit,
             --disallow-untyped-calls,
             --disallow-untyped-defs,
             --disallow-incomplete-defs,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,8 @@ repos:
     hooks:
     -   id: black
         language_version: python3.8
+        args:
+          ["--line-length=100"]
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0  # Use the ref you want to point at
@@ -18,7 +20,7 @@ repos:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: mixed-line-ending
-        args: ['--fix=lf']
+        args: ["--fix=lf"]
         description: Forces line endings to the UNIX LF character
 
 -   repo: https://github.com/pre-commit/mirrors-mypy

--- a/.pylintrc
+++ b/.pylintrc
@@ -85,7 +85,9 @@ disable=raw-checker-failed,
         suppressed-message,
         useless-suppression,
         deprecated-pragma,
-        use-symbolic-message-instead
+        use-symbolic-message-instead,
+		too-many-public-methods,
+		unsubscriptable-object
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/.pylintrc
+++ b/.pylintrc
@@ -9,7 +9,7 @@ extension-pkg-allow-list=cv2
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code. (This is an alternative name to extension-pkg-allow-list
 # for backward compatibility.)
-extension-pkg-whitelist=
+extension-pkg-whitelist=cv2
 
 # Return non-zero exit code if any of these messages/categories are detected,
 # even if score is above --fail-under value. Syntax same as enable. Messages


### PR DESCRIPTION
This commit includes enhancements to the pre-commit hooks on the repo and includes the following:
- Remove the mypy's disallowing of explicit Any typing
- Increases the maximum line length that Black uses to 100
- Adds image and video files to the gitignore
- Moves the mypy configuration from the pre-commit config to a separate mypy init config file