### PR TITLE
Add bad-continuation exclusion

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -87,7 +87,8 @@ disable=raw-checker-failed,
         deprecated-pragma,
         use-symbolic-message-instead,
 		too-many-public-methods,
-		unsubscriptable-object
+		unsubscriptable-object,
+		bad-continuation
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option


### PR DESCRIPTION
I recently discovered that this is an issue contradictory to the type of reformatting done by black.
For example, an if statement with a long line is broken down into multiple lines, but pylint is unsatisfied with the indentation scheme.