### PR TITLE
ODLC Text Orientation

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -499,7 +499,7 @@ ignored-parents=
 max-args=5
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes=7
+max-attributes=8
 
 # Maximum number of boolean expressions in an if statement (see R0916).
 max-bool-expr=5

--- a/vision/Object Detection/standard_obj_text.py
+++ b/vision/Object Detection/standard_obj_text.py
@@ -116,7 +116,7 @@ class TextCharacteristics:
         self._rotated_img = image
 
     def get_text_characteristics(
-        self, bounds: BoundingBox
+        self, bounds: BoundingBox, drone_degree: float
     ) -> Tuple[Optional[str], Optional[str], Optional[str]]:
         """
         Gets the characteristics of the text on the standard object.
@@ -126,6 +126,8 @@ class TextCharacteristics:
         ----------
         bounds : BoundingBox
             bounds of standard object containing text on in image
+        drone_degree : float
+            rotation angle of the drone relative to north
 
         Returns
         -------
@@ -143,9 +145,9 @@ class TextCharacteristics:
         character, char_bounds = characters[0]
 
         ## Get the orientation ##
-        # NOTE: Not implemented
-        # orientation: Optional[str] = self._get_orientation()
-        orientation: Optional[str] = "N"
+        orientation: Optional[str] = self.get_orientation(
+            drone_degree=drone_degree, obj_bounds=bounds, char_bounds=char_bounds
+        )
 
         ## Get the color of the text ##
         color: Optional[str] = self.get_text_color(char_bounds)
@@ -560,16 +562,19 @@ if __name__ == "__main__":
         ((77, 184), (3, 91), (120, 0), (194, 82)), ObjectType.STD_OBJECT
     )
 
+    # angle of the drone, 0 for testing
+    DRONE_ANGLE = 0
+
     detector: TextCharacteristics = TextCharacteristics()
     detector.img = test_img
     detected_chars: Tuple[
         Optional[str], Optional[str], Optional[str]
-    ] = detector.get_text_characteristics(test_bounds)
+    ] = detector.get_text_characteristics(test_bounds, DRONE_ANGLE)
 
     # Code for testing orientation
-    # drone_angle = 0
+    # DRONE_ANGLE = 0
     # odlc_bounds = BoundingBox(((0, 0), (100, 0), (100, 100), (0, 100)), obj_type=ObjectType.TEXT)
     # text_bounds = BoundingBox(((0, 0), (10, 0), (10, 10), (0, 10)), obj_type=ObjectType.TEXT)
-    # print(detector.get_orientation(drone_angle, odlc_bounds, text_bounds))
+    # print(detector.get_orientation(DRONE_ANGLE, odlc_bounds, text_bounds))
 
     print("The following character was found in the image:", detected_chars)

--- a/vision/Object Detection/standard_obj_text.py
+++ b/vision/Object Detection/standard_obj_text.py
@@ -134,6 +134,7 @@ class TextCharacteristics:
             bounds of standard object containing text on in image
         drone_degree : float
             rotation angle of the drone relative to north
+            this is the yaw degree
 
         Returns
         -------
@@ -506,6 +507,7 @@ class TextCharacteristics:
         ----------
         drone_degree : float
             rotation angle of the drone relative to north
+            this is the yaw degree
         obj_bounds : BoundingBox
             bounds of the standard object on which the text is contained
         char_bounds : BoundingBox
@@ -533,9 +535,9 @@ class TextCharacteristics:
 
         # get which range angle falls into
         octant: int = int(total_angle // dir_width)
-        orientation = POSSIBLE_ORIENTATIONS[octant]
+        self.orientation = POSSIBLE_ORIENTATIONS[octant]
 
-        return orientation
+        return self.orientation
 
 
 # Driver for testing text detection and classification functions.

--- a/vision/Object Detection/standard_obj_text.py
+++ b/vision/Object Detection/standard_obj_text.py
@@ -46,6 +46,11 @@ class TextCharacteristics:
     """
     Class for detecting characteristics of text on standard objects.
     Characteristics are of the character, orientation, and color.
+
+    Parameters
+    ----------
+    _img : Optional[npt.NDArray[np.uint8]]
+        the image to find characteristics within
     """
 
     def __init__(self, img: Optional[npt.NDArray[np.uint8]] = None) -> None:
@@ -120,6 +125,7 @@ class TextCharacteristics:
     ) -> Tuple[Optional[str], Optional[str], Optional[str]]:
         """
         Gets the characteristics of the text on the standard object.
+        The characteristics are character, orientation, and color.
         NOTE: Need to set image before calling.
 
         Parameters
@@ -138,7 +144,7 @@ class TextCharacteristics:
         """
         ## Get the character ##
         characters: List[Tuple[str, BoundingBox]] = self.detect_text(bounds)
-        if len(characters) != 1:
+        if len(characters) != 1:  # failed if more than 1 character found
             return (None, None, None)
         character: str
         char_bounds: BoundingBox

--- a/vision/common/bounding_box.py
+++ b/vision/common/bounding_box.py
@@ -204,7 +204,11 @@ class BoundingBox:
         tl_y: int = self.vertices[0][1]
         tr_y: int = self.vertices[1][1]
 
-        angle: float = np.rad2deg(np.arctan((tr_y - tl_y) / (tr_x - tl_x)))
+        angle: float = 0
+        if tr_x - tl_x == 0:  # prevent division by 0
+            angle = 90.0 if (tr_y - tl_y > 0) else -90.0
+        else:
+            angle = np.rad2deg(np.arctan((tr_y - tl_y) / (tr_x - tl_x)))
 
         return angle
 


### PR DESCRIPTION
closes #24 

### Changes

- Fixed divide by 0 error in BoundingBox angle calculation
- Implemented TextCharacteristics.get_orientation() to calculate the orientation of the text based on the bounds of the ODLC and text and the orientation of the drone
- Added use of newly implemented orientation function to characteristics function
- Minor documentation updates