### PR TITLE
Feature/odlc search grid

### DIFF
--- a/flight/odlc_search_grid/main.py
+++ b/flight/odlc_search_grid/main.py
@@ -1,0 +1,32 @@
+import plotter
+import search_path
+
+
+search_area = [
+    {
+        "altitudeMin": 100.0,
+        "altitudeMax": 400.0,
+        "boundaryPoints": [
+            {"latitude": 37.95120673695754, "longitude": -91.78693406657685},
+            {"latitude": 37.951248325955994, "longitude": -91.78207299965484},
+            {"latitude": 37.948226725559984, "longitude": -91.78191292975686},
+            {"latitude": 37.94711526778687, "longitude": -91.78116415681103},
+            {"latitude": 37.94623824627026, "longitude": -91.78490802154013},
+            {"latitude": 37.94797658615526, "longitude": -91.78697801835733},
+            {"latitude": 37.95120673695754, "longitude": -91.78693406657685},
+        ],
+    }
+][0]
+
+if __name__ == "__main__":
+    search_area_points = search_area["boundaryPoints"]
+
+    # Add utm coordinates to all
+    search_area_points = search_path.all_latlon_to_utm(search_area_points)
+
+    # Generate search path
+    buffer_distance = -50
+    search_paths = search_path.generate_search_path(search_area_points, buffer_distance)
+
+    # Plot data
+    plotter.plot_data(search_paths)

--- a/flight/odlc_search_grid/main.py
+++ b/flight/odlc_search_grid/main.py
@@ -1,3 +1,7 @@
+"""
+Sample runner to test the search paths feature
+"""
+
 import plotter
 import search_path
 
@@ -25,8 +29,13 @@ if __name__ == "__main__":
     search_area_points = search_path.all_latlon_to_utm(search_area_points)
 
     # Generate search path
-    buffer_distance = -50
-    search_paths = search_path.generate_search_path(search_area_points, buffer_distance)
+    BUFFER_DISTANCE = -50  # use height/2 of camera image as buffer distance
+    search_paths = search_path.generate_search_paths(search_area_points, BUFFER_DISTANCE)
+
+    # fly all points in search_paths[0],
+    # when you reach your starting point,
+    # fly all points in search_paths[1],
+    # etc... until all search paths have been flown
 
     # Plot data
     plotter.plot_data(search_paths)

--- a/flight/odlc_search_grid/plotter.py
+++ b/flight/odlc_search_grid/plotter.py
@@ -1,0 +1,18 @@
+"""
+Provides plotting functionality for visualizing coordinate data
+"""
+
+from typing import List, Dict, Tuple
+import matplotlib.pyplot as plt
+
+
+def plot_data(search_paths) -> None:
+    for path in search_paths:
+        x, y = [], []
+        for point in path:
+            x.append(point[0])
+            y.append(point[1])
+        plt.plot(x, y, "ro-")
+
+    plt.gca().set_aspect(1)
+    plt.show()

--- a/flight/odlc_search_grid/plotter.py
+++ b/flight/odlc_search_grid/plotter.py
@@ -2,11 +2,19 @@
 Provides plotting functionality for visualizing coordinate data
 """
 
-from typing import List, Dict, Tuple
+from typing import List, Tuple
 import matplotlib.pyplot as plt
 
 
-def plot_data(search_paths) -> None:
+def plot_data(search_paths: List[List[Tuple[float, float]]]) -> None:
+    """Simple plotter function to plot the search paths
+
+    Parameters
+    ----------
+    search_paths : List[Tuple[float, float]]
+        A list of search paths to be plotted
+    """
+
     for path in search_paths:
         x, y = [], []
         for point in path:

--- a/flight/odlc_search_grid/search_path.py
+++ b/flight/odlc_search_grid/search_path.py
@@ -1,0 +1,72 @@
+"""
+Functions for generating a search path for standard odlc objects
+"""
+
+from typing import List, Dict, Tuple
+
+from shapely.geometry import Point, Polygon
+from shapely.ops import nearest_points
+import utm
+
+
+def latlon_to_utm(coords: Dict[str, float]) -> Dict[str, float]:
+    """Converts latlon coordinates to utm coordinates and adds the data to the dictionary
+
+    Parameters
+    ----------
+    coords : Dict[str, float]
+        A dictionary containing lat long coordinates
+
+    Returns
+    -------
+    Dict[str, float]
+        An updated dictionary with additional keys and values with utm data
+    """
+
+    utm_coords = utm.from_latlon(coords["latitude"], coords["longitude"])
+    coords["utm_x"] = utm_coords[0]
+    coords["utm_y"] = utm_coords[1]
+    coords["utm_zone_number"] = utm_coords[2]
+    coords["utm_zone_letter"] = utm_coords[3]
+    return coords
+
+
+def all_latlon_to_utm(list_of_coords: List[Dict[str, float]]) -> List[Dict[str, float]]:
+    """Converts a list of dictionaries with latlon data to add utm data
+
+    Parameters
+    ----------
+    list_of_coords : List[Dict[str, float]]
+        A list of dictionaries that contain lat long data
+
+    Returns
+    -------
+    List[Dict[str, float]]
+        list[dict]: An updated list of dictionaries with added utm data
+    """
+
+    for i, _ in enumerate(list_of_coords):
+        list_of_coords[i] = latlon_to_utm(list_of_coords[i])
+    return list_of_coords
+
+
+# use height/2 of camera image as buffer distance
+def generate_search_path(search_area_points, buffer_distance):
+    poly_points = [(point["utm_x"], point["utm_y"]) for point in search_area_points]
+
+    boundary_shape = Polygon(poly_points)
+
+    search_paths = []
+    search_paths.append(
+        list(zip(*boundary_shape.exterior.coords.xy))  # pylint: disable=maybe-no-member
+    )
+
+    while True:
+        boundary_shape = boundary_shape.buffer(buffer_distance, single_sided=True)
+        if boundary_shape.area <= 0:
+            break
+        search_paths.append(
+            list(zip(*boundary_shape.exterior.coords.xy))  # pylint: disable=maybe-no-member
+        )
+
+    return search_paths


### PR DESCRIPTION
This feature is to add the ability for the drone to cover an entire search area by flying consecutively smaller paths of the original boundary shape. The idea is that the drone will start on the outer path, fly it, and then once it reaches it's starting point, move to the next path in the list.

Specifically, the function generate_search_paths() should be passed the original bounding search area, and a buffer distance (equal to height of the camera coverage on the ground divided by 2). The function returns a list of search paths, where each search path is a list of coordinate tuples.

This feature only generates the paths. Flying them in an orderly manner will be handled elsewhere.

<img width="333" alt="image" src="https://user-images.githubusercontent.com/9341559/164111018-3e990168-030e-4c1b-a178-e7d83e384a19.png">
