### PR TITLE
Fix mypy not recognizing numpy and update pylint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,9 +29,10 @@ repos:
     hooks:
     -   id: mypy
         args: ["--config-file=.mypy.ini"]
+        additional_dependencies: ['numpy>=1.21.2']
 
 -   repo: https://github.com/PyCQA/pylint
-    rev: 'v2.13.5'
+    rev: 'v2.13.7'
     hooks:
     -   id: pylint
         name: pylint


### PR DESCRIPTION
This pull request fixes an issue with mypy that causes it to not recognize numpy and thus completely ignore any references to it.