### PR TITLE
Fix issue with pylint sometimes contradicting with black 

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -90,7 +90,8 @@ disable=raw-checker-failed,
         deprecated-pragma,
         use-symbolic-message-instead,
         too-many-public-methods,
-        unsubscriptable-object
+        unsubscriptable-object,
+        bad-continuation
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option


### PR DESCRIPTION
This pull request fixes a contradiction between pylint and black that causes formatting in indentation of multiline function headers to be flagged as incorrect when they do in fact comply with PEP 8